### PR TITLE
Improve CI resilience and exclude GHC-8.8.3 on Windows

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -35,9 +35,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        cabal v2-update
+        cabal v2-update || cabal v2-update
+        cabal v2-build --only-dependencies --enable-tests --enable-benchmarks || \
         cabal v2-build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
-      run: cabal v2-build
+      run: cabal v2-build || cabal v2-build
     - name: Test
       run: cabal v2-test

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,8 +36,7 @@ jobs:
     - name: Install dependencies
       run: |
         cabal v2-update || cabal v2-update
-        cabal v2-build --only-dependencies --enable-tests --enable-benchmarks || \
-          cabal v2-build --only-dependencies --enable-tests --enable-benchmarks
+        cabal v2-build --only-dependencies --enable-tests --enable-benchmarks || cabal v2-build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
       run: cabal v2-build || cabal v2-build
     - name: Test

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         cabal v2-update || cabal v2-update
         cabal v2-build --only-dependencies --enable-tests --enable-benchmarks || \
-        cabal v2-build --only-dependencies --enable-tests --enable-benchmarks
+          cabal v2-build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
       run: cabal v2-build || cabal v2-build
     - name: Test

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ['8.6.5', '8.8.3', '8.10.1']
+        ghc: ['8.6', '8.8', '8.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     name: GHC ${{ matrix.ghc }} / ${{ matrix.os }}
     steps:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         ghc: ['8.6', '8.8', '8.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
+      exclude:
+        # 8.8.3 on windows throws segfaults when installing deps
+        - os: windows-latest
+          ghc: '8.8'
     name: GHC ${{ matrix.ghc }} / ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,10 +13,10 @@ jobs:
       matrix:
         ghc: ['8.6', '8.8', '8.10']
         os: [ubuntu-latest, macOS-latest, windows-latest]
-      exclude:
-        # 8.8.3 on windows throws segfaults when installing deps
-        - os: windows-latest
-          ghc: '8.8'
+        exclude:
+          # 8.8.3 on windows throws segfaults when installing deps
+          - os: windows-latest
+            ghc: '8.8'
     name: GHC ${{ matrix.ghc }} / ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I couldn't figure out why GHC-8.8.3 segfaults on Windows so I've just excluded that configuration from the test matrix.