### PR TITLE
Speed up fromListN

### DIFF
--- a/compact-sequences.cabal
+++ b/compact-sequences.cabal
@@ -32,12 +32,15 @@ library
                  , Data.CompactSequence.Queue.Simple.Internal
                  , Data.CompactSequence.Queue.Internal
                  , Data.CompactSequence.Internal.Array
+                 , Data.CompactSequence.Internal.Numbers
                  , Data.CompactSequence.Internal.Array.Safe
   -- other-modules:
   -- other-extensions:
   build-depends:       base >=4.10.0.0 && < 5.0
-                     , primitive
-                     , transformers
+                       -- Lower bound for runSmallArray
+                     , primitive >= 0.6.4.0
+                       -- We use this for State.
+                     , mtl
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/src/Data/CompactSequence/Internal/Numbers.hs
+++ b/src/Data/CompactSequence/Internal/Numbers.hs
@@ -1,0 +1,49 @@
+module Data.CompactSequence.Internal.Numbers where
+import Data.Bits
+
+-- A representation of 1-2 binary numbers. We use this to build stacks or stack
+-- fragments of known size.
+data Dyadic = DOne !Dyadic | DTwo !Dyadic | DEnd
+  deriving (Eq, Show)
+
+toDyadic :: Int -> Dyadic
+toDyadic n0 = go (n0 + 1)
+  where
+    go 1 = DEnd
+    go n = case n .&. 1 of
+      0 -> DOne $ go (unsafeShiftR n 1)
+      _ -> DTwo $ go (unsafeShiftR n 1)
+{-# NOINLINE toDyadic #-}
+
+{-
+-- We'll have to figure out how to write something
+-- like this to append stacks more efficiently.
+incDyadic :: Dyadic -> Dyadic
+incDyadic DEnd = DOne DEnd
+incDyadic (DOne n) = DTwo n
+incDyadic (DTwo n) = DOne (incDyadic n)
+
+addDyadic :: Dyadic -> Dyadic -> Dyadic
+addDyadic = go 0
+  where
+    go 0 DEnd !n = n
+    go 1 DEnd !n = incDyadic n
+    go _ DEnd !n = incDyadic (incDyadic n)
+    go !c !n DEnd = go c DEnd n
+    go !c 
+-}
+
+-- A representation of 2-3 binary numbers, where the most significant digit may
+-- also be 1. We use this to build stacks or stack fragments of known size.
+data Bin23 = Two23 !Bin23 | Three23 !Bin23 | End23 | OneEnd23
+  deriving (Eq, Show)
+
+toBin23 :: Int -> Bin23
+toBin23 n0 = go (n0 + 2)
+  where
+    go 2 = End23
+    go 3 = OneEnd23
+    go n = case n .&. 1 of
+      0 -> Two23 $ go (unsafeShiftR n 1)
+      _ -> Three23 $ go (unsafeShiftR n 1)
+{-# NOINLINE toBin23 #-}

--- a/src/Data/CompactSequence/Queue/Simple.hs
+++ b/src/Data/CompactSequence/Queue/Simple.hs
@@ -15,6 +15,7 @@ module Data.CompactSequence.Queue.Simple
   , take
   , fromList
   , fromListN
+  , fromListNIncremental
   ) where
 
 import Data.CompactSequence.Queue.Simple.Internal

--- a/test/Stack.hs
+++ b/test/Stack.hs
@@ -37,8 +37,9 @@ instance Arbitrary a => Arbitrary (Stack a) where
                       <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
                       <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
                       <*> go (A.twice ars) (n - 3 * A.getSize ars)
-  -- We shrink by trimming the spine. I doubt any other
-  -- shrinks are really useful for our purposes.
+
+  -- We shrink by trimming the spine. Any other shrinks will
+  -- be tricky.
   shrink (Stack stk) = [ Stack (takeSpine k stk) | k <- [0..depth stk]]
     where
       depth :: SI.Stack n a -> Int


### PR DESCRIPTION
* Use a fast `O(log n)` algorithm to calculate the shape of the result
  stack/queue of `fromListN`. We previously used a naive `O(n)`
  "counting" algorithm.

* Implement `fromListNIncremental` for queues, which converts a
  list to a queue one node at a time.

Closes #9