### PR TITLE
Calculate deque lengths faster

### DIFF
--- a/src/Data/CompactSequence/Internal/Array.hs
+++ b/src/Data/CompactSequence/Internal/Array.hs
@@ -5,7 +5,6 @@
 {-# language RoleAnnotations #-}
 {-# language MagicHash #-}
 {-# language UnboxedTuples #-}
-{-# language NoStarIsType #-}
 {-# language RankNTypes #-}
 {-# language DeriveTraversable #-}
 {-# language Unsafe #-}

--- a/src/Data/CompactSequence/Stack/Internal.hs
+++ b/src/Data/CompactSequence/Stack/Internal.hs
@@ -2,7 +2,6 @@
 {-# language TypeFamilies #-}
 {-# language DataKinds #-}
 {-# language TypeOperators #-}
-{-# language NoStarIsType #-}
 {-# language Safe #-}
 {-# language ScopedTypeVariables #-}
 {-# language InstanceSigs #-}


### PR DESCRIPTION
Also remove unneeded `NoStarIsType`