### PR TITLE
Adjust operator precedence

### DIFF
--- a/compact-sequences.cabal
+++ b/compact-sequences.cabal
@@ -16,7 +16,7 @@ license:             BSD-3-Clause
 license-file:        LICENSE
 author:              David Feuer
 maintainer:          David.Feuer@gmail.com
-copyright: 2020 David Feuer
+copyright:           2020 David Feuer
 category:            Data
 extra-source-files:  CHANGELOG.md
 

--- a/src/Data/CompactSequence/Deque/Simple/Internal.hs
+++ b/src/Data/CompactSequence/Deque/Simple/Internal.hs
@@ -89,11 +89,15 @@ infixl 4 `snoc`, |>
 -- front of a deque.
 pattern (:<) :: a -> Deque a -> Deque a
 pattern x :< xs <- (uncons -> Just (x, xs))
+  where
+    x :< xs = x `cons` xs
 
 -- | A bidirectional pattern synonym for manipulating the
 -- rear of a deque.
 pattern (:>) :: Deque a -> a -> Deque a
 pattern xs :> x <- (unsnoc -> Just (xs, x))
+  where
+    xs :> x = xs `snoc` x
 
 -- | A bidirectional pattern synonym for the empty deque.
 pattern Empty :: Deque a

--- a/src/Data/CompactSequence/Deque/Simple/Internal.hs
+++ b/src/Data/CompactSequence/Deque/Simple/Internal.hs
@@ -82,7 +82,7 @@ unsnoc (Deque q) = case D.viewRA A.one q of
     | (# a #) <- A.getSingleton# ta
     -> Just (Deque q', a)
 
-infixr 4 :<
+infixr 5 :<, `cons`
 infixl 4 `snoc`, |>
 
 -- | A bidirectional pattern synonym for manipulating the

--- a/src/Data/CompactSequence/Queue/Simple/Internal.hs
+++ b/src/Data/CompactSequence/Queue/Simple/Internal.hs
@@ -64,7 +64,7 @@ uncons (Queue q) = case Q.viewA A.one q of
     | (# a #) <- A.getSingleton# sa
     -> Just (a, Queue q')
 
-infixr 4 :<
+infixr 5 :<
 infixl 4 `snoc`, |>
 
 -- | A unidirectional pattern synonym for viewing the

--- a/src/Data/CompactSequence/Stack/Simple/Internal.hs
+++ b/src/Data/CompactSequence/Stack/Simple/Internal.hs
@@ -45,7 +45,7 @@ newtype Stack a = Stack {unStack :: S.Stack A.Mul1 a}
 empty :: Stack a
 empty = Stack S.empty
 
-infixr 4 `cons`, :<, <|
+infixr 5 `cons`, :<, <|
 
 -- | Push an element onto the front of a stack.
 cons :: a -> Stack a -> Stack a


### PR DESCRIPTION
As discussed on the libraries list, this is a bit of a minefield.  I
want cons and snoc operators and patterns to have different precedence
in case someone wants to write something like `x :< as :> y`. I wish I
could give one operator precedence 5 and the other
4.5 or 5.5, but we don't have fractional precedence. Precedence
5 matches that of `:`, which is pleasantly higher precedence than
`Functor` and `Applicative` operators and lower precedence than
standard arithmetic operators. Running into arithmetic seems
particularly troublesome, so let's go with 4 and 5. There's no
good choice for which gets which, since queues want one thing
and stacks want the other. I'm going with `:<` having the higher
precedence to match `:`; nothing very principled, but that was
Henning Thielemann's instinct.

Closes #13

Also make the deque pattern synonyms bidirectional, as they were always supposed to be.