### PR TITLE
Improve size situation

### DIFF
--- a/compact-sequences.cabal
+++ b/compact-sequences.cabal
@@ -35,6 +35,7 @@ library
                  , Data.CompactSequence.Deque.Simple.Internal
                  , Data.CompactSequence.Deque.Internal
                  , Data.CompactSequence.Internal.Array
+                 , Data.CompactSequence.Internal.Size
                  , Data.CompactSequence.Internal.Numbers
                  , Data.CompactSequence.Internal.Array.Safe
   -- other-modules:

--- a/src/Data/CompactSequence/Internal/Array.hs
+++ b/src/Data/CompactSequence/Internal/Array.hs
@@ -1,5 +1,3 @@
-{-# language DataKinds #-}
-{-# language TypeOperators #-}
 {-# language KindSignatures #-}
 {-# language BangPatterns #-}
 {-# language RoleAnnotations #-}
@@ -11,32 +9,16 @@
 {- OPTIONS_GHC -ddump-simpl #-}
 
 module Data.CompactSequence.Internal.Array where
+import Data.CompactSequence.Internal.Size
 import Data.Primitive.SmallArray
 import Control.Monad.ST.Strict
 import GHC.Exts (SmallArray#)
 
-data Mult = Twice Mult | Mul1
-
-newtype Array (n :: Mult) a = Array (SmallArray a)
+newtype Array n a = Array (SmallArray a)
   deriving (Functor, Foldable, Traversable)
 type role Array nominal representational
 
-newtype Size (n :: Mult) = Size Int
-type role Size nominal
-
-getSize :: Size n -> Int
-getSize (Size n) = n
-
---halve :: Size (Twice m) -> Size m
---halve (Size n) = Size (n `quot` 2)
-
-one :: Size Mul1
-one = Size 1
-
-twice :: Size n -> Size (Twice n)
-twice (Size n) = Size (2*n)
-
-singleton :: a -> Array Mul1 a
+singleton :: a -> Array Sz1 a
 singleton x = Array (pure x)
 
 -- | Unsafely convert a 'SmallArray' of size @n@
@@ -49,10 +31,10 @@ unsafeSmallArrayToArray = Array
 arrayToSmallArray :: Array n a -> SmallArray a
 arrayToSmallArray (Array sa) = sa
 
-getSingleton# :: Array Mul1 a -> (# a #)
+getSingleton# :: Array Sz1 a -> (# a #)
 getSingleton# (Array sa) = indexSmallArray## sa 0
 
-getSingletonA :: Applicative f => Array Mul1 a -> f a
+getSingletonA :: Applicative f => Array Sz1 a -> f a
 getSingletonA (Array sa)
   | (# a #) <- indexSmallArray## sa 0
   = pure a

--- a/src/Data/CompactSequence/Internal/Array/Safe.hs
+++ b/src/Data/CompactSequence/Internal/Array/Safe.hs
@@ -2,12 +2,7 @@
 {-# language Trustworthy #-}
 
 module Data.CompactSequence.Internal.Array.Safe
-  ( Mult (..)
-  , Array
-  , Size
-  , getSize
-  , one
-  , twice
+  ( Array
   , singleton
   , getSingleton#
   , getSingletonA

--- a/src/Data/CompactSequence/Internal/Size.hs
+++ b/src/Data/CompactSequence/Internal/Size.hs
@@ -1,0 +1,107 @@
+{-# language BangPatterns #-}
+{-# language RoleAnnotations #-}
+{-# language Safe #-}
+{- OPTIONS_GHC -ddump-simpl #-}
+
+{- |
+Array sizes with phantom types. We use a very primitive
+arrangement because that's all we need for now: the base
+type is 'Sz1', 'Sz2', etc., and it's doubled as many times
+as necessary by applying
+the @Twice@ constructor. The base value is 'sz1', 'sz2',
+etc., and it's doubled by applying the 'twice' function.
+-}
+module Data.CompactSequence.Internal.Size where
+
+data Twice a
+data Sz1
+data Sz2
+data Sz3
+data Sz4
+data Sz5
+data Sz6
+data Sz7
+data Sz8
+data Sz9
+data Sz10
+data Sz11
+data Sz12
+data Sz13
+data Sz14
+data Sz15
+data Sz16
+data Sz17
+data Sz18
+data Sz19
+
+newtype Size n = Size Int
+type role Size nominal
+
+getSize :: Size n -> Int
+getSize (Size n) = n
+
+twice :: Size n -> Size (Twice n)
+twice (Size n) = Size (2*n)
+
+half :: Size (Twice m) -> Size m
+half (Size n) = Size (n `quot` 2)
+
+one :: Size Sz1
+one = Size 1
+
+sz1 :: Size Sz1
+sz1 = Size 1
+
+sz2 :: Size Sz2
+sz2 = Size 2
+
+sz3 :: Size Sz3
+sz3 = Size 3
+
+sz4 :: Size Sz4
+sz4 = Size 4
+
+sz5 :: Size Sz5
+sz5 = Size 5
+
+sz6 :: Size Sz6
+sz6 = Size 6
+
+sz7 :: Size Sz7
+sz7 = Size 7
+
+sz8 :: Size Sz8
+sz8 = Size 8
+
+sz9 :: Size Sz9
+sz9 = Size 9
+
+sz10 :: Size Sz10
+sz10 = Size 10
+
+sz11 :: Size Sz11
+sz11 = Size 11
+
+sz12 :: Size Sz12
+sz12 = Size 12
+
+sz13 :: Size Sz13
+sz13 = Size 13
+
+sz14 :: Size Sz14
+sz14 = Size 14
+
+sz15 :: Size Sz15
+sz15 = Size 15
+
+sz16 :: Size Sz16
+sz16 = Size 16
+
+sz17 :: Size Sz17
+sz17 = Size 17
+
+sz18 :: Size Sz18
+sz18 = Size 18
+
+sz19 :: Size Sz19
+sz19 = Size 19

--- a/test/Deque.hs
+++ b/test/Deque.hs
@@ -15,6 +15,7 @@ import Data.CompactSequence.Deque.Simple.Internal
 import qualified Data.CompactSequence.Deque.Simple.Internal as D
 import qualified Data.CompactSequence.Deque.Internal as DI
 import qualified Data.CompactSequence.Internal.Array.Safe as A
+import qualified Data.CompactSequence.Internal.Size as Sz
 import Prelude as P
 
 instance Arbitrary a => Arbitrary (Deque a) where
@@ -22,29 +23,29 @@ instance Arbitrary a => Arbitrary (Deque a) where
   -- of magnitude as the size parameter, with any shape.
   arbitrary = sized $ \sz0 -> do
     sz <- choose (0, sz0)
-    Deque <$> go A.one sz
+    Deque <$> go Sz.one sz
     where
-      go :: A.Size n -> Int -> Gen (DI.Deque n a)
+      go :: Sz.Size n -> Int -> Gen (DI.Deque n a)
       go !ars n
         | n <= 0 = pure DI.Empty
-        | n <= A.getSize ars = DI.Shallow <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
+        | n <= Sz.getSize ars = DI.Shallow <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
       go !ars n = do
         frontSize <- choose (1,4 :: Int)
         rearSize <- choose (1,4 :: Int)
-        m <- go (A.twice ars) (n - (frontSize + rearSize) * A.getSize ars)
+        m <- go (Sz.twice ars) (n - (frontSize + rearSize) * Sz.getSize ars)
         DI.Deep <$> dig ars frontSize <*> pure m <*> dig ars rearSize
 
       dig !ars = \case
-        1 -> DI.One <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-        2 -> DI.Two <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-        3 -> DI.Three <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-        _ -> DI.Four <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
+        1 -> DI.One <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+        2 -> DI.Two <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+        3 -> DI.Three <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+        _ -> DI.Four <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
 
 {-
   -- We shrink by trimming the spine. Any other shrinks will

--- a/test/Queue.hs
+++ b/test/Queue.hs
@@ -15,6 +15,7 @@ import Data.CompactSequence.Queue.Simple.Internal
 import qualified Data.CompactSequence.Queue.Simple.Internal as Q
 import qualified Data.CompactSequence.Queue.Internal as QI
 import qualified Data.CompactSequence.Internal.Array.Safe as A
+import qualified Data.CompactSequence.Internal.Size as Sz
 import Prelude as P
 
 instance Arbitrary a => Arbitrary (Queue a) where
@@ -22,30 +23,30 @@ instance Arbitrary a => Arbitrary (Queue a) where
   -- of magnitude as the size parameter, with any shape.
   arbitrary = sized $ \sz0 -> do
     sz <- choose (0, sz0)
-    Queue <$> go A.one sz
+    Queue <$> go Sz.one sz
     where
-      go :: A.Size n -> Int -> Gen (QI.Queue n a)
+      go :: Sz.Size n -> Int -> Gen (QI.Queue n a)
       go !_ars n
         | n <= 0 = pure QI.Empty
       go !ars n = do
         frontSize <- choose (1,3 :: Int)
         rearSize <- choose (0,2 :: Int)
-        m <- go (A.twice ars) (n - (frontSize + rearSize) * A.getSize ars)
+        m <- go (Sz.twice ars) (n - (frontSize + rearSize) * Sz.getSize ars)
         QI.Node <$> pr ars frontSize <*> pure m <*> sf ars rearSize
 
       pr !ars = \case
-        1 -> QI.FD1 <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-        2 -> QI.FD2 <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-        _ -> QI.FD3 <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
+        1 -> QI.FD1 <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+        2 -> QI.FD2 <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+        _ -> QI.FD3 <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
 
       sf !ars = \case
         0 -> pure QI.RD0
-        1 -> QI.RD1 <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-        _ -> QI.RD2 <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
+        1 -> QI.RD1 <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+        _ -> QI.RD2 <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
 
   -- We shrink by trimming the spine. Any other shrinks will
   -- be tricky.

--- a/test/Stack.hs
+++ b/test/Stack.hs
@@ -15,6 +15,7 @@ import Data.CompactSequence.Stack.Simple.Internal
 import qualified Data.CompactSequence.Stack.Simple.Internal as S
 import qualified Data.CompactSequence.Stack.Internal as SI
 import qualified Data.CompactSequence.Internal.Array.Safe as A
+import qualified Data.CompactSequence.Internal.Size as Sz
 import Prelude as P
 
 instance Arbitrary a => Arbitrary (Stack a) where
@@ -22,21 +23,21 @@ instance Arbitrary a => Arbitrary (Stack a) where
   -- of magnitude as the size parameter, with any shape.
   arbitrary = sized $ \sz0 -> do
     sz <- choose (0, sz0)
-    Stack <$> go A.one sz
+    Stack <$> go Sz.one sz
     where
-      go :: A.Size n -> Int -> Gen (SI.Stack n a)
+      go :: Sz.Size n -> Int -> Gen (SI.Stack n a)
       go !_ars n
         | n <= 0 = pure SI.Empty
       go !ars n = choose (1,3 :: Int) >>= \case
-        1 -> SI.One <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> go (A.twice ars) (n - A.getSize ars)
-        2 -> SI.Two <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                    <*> go (A.twice ars) (n - 2 * A.getSize ars)
-        3 -> SI.Three <$> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                      <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                      <*> (A.fromList ars <$> vectorOf (A.getSize ars) arbitrary)
-                      <*> go (A.twice ars) (n - 3 * A.getSize ars)
+        1 -> SI.One <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> go (Sz.twice ars) (n - Sz.getSize ars)
+        2 -> SI.Two <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                    <*> go (Sz.twice ars) (n - 2 * Sz.getSize ars)
+        3 -> SI.Three <$> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                      <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                      <*> (A.fromList ars <$> vectorOf (Sz.getSize ars) arbitrary)
+                      <*> go (Sz.twice ars) (n - 3 * Sz.getSize ars)
 
   -- We shrink by trimming the spine. Any other shrinks will
   -- be tricky.


### PR DESCRIPTION
* Split out the size stuff from the array module.
* Give sizes kind `Type` so we can pick an arbitrary base size.
* Add a bunch of base sizes we can use as needed. Each will need
  construction and destruction functions in the array module, but
  we can deal with that later. Is this really the right approach?
  I dunno, but it should get us off the ground without anything
  heavy.